### PR TITLE
Fixed ESP-IDF 4.0 compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Due to [this issue](https://github.com/nkolban/esp32-snippets/issues/797), remov
 ### 2) Add new static method to kill BLE server properly
 
 Add removeServer() method to BLEDevice class, so that the programmer could deinitialise the BLE server(kill the BLE server).
+
+### 3) Creates a bunch of fixes for GCC warnings and errors
+
+View commits for more information.

--- a/cpp_utils/BLECharacteristic.cpp
+++ b/cpp_utils/BLECharacteristic.cpp
@@ -657,18 +657,18 @@ void BLECharacteristic::setValue(uint8_t* data, size_t length) {
  * @param [in] Set the value of the characteristic.
  * @return N/A.
  */
-void BLECharacteristic::setValue(std::string value) {
+void BLECharacteristic::setValue(std::string& value) {
 	setValue((uint8_t*)(value.data()), value.length());
 } // setValue
 
-void BLECharacteristic::setValue(uint16_t& data16) {
+void BLECharacteristic::setValue(uint16_t data16) {
 	uint8_t temp[2];
 	temp[0] = data16;
 	temp[1] = data16 >> 8;
 	setValue(temp, 2);
 } // setValue
 
-void BLECharacteristic::setValue(uint32_t& data32) {
+void BLECharacteristic::setValue(uint32_t data32) {
 	uint8_t temp[4];
 	temp[0] = data32;
 	temp[1] = data32 >> 8;
@@ -677,7 +677,7 @@ void BLECharacteristic::setValue(uint32_t& data32) {
 	setValue(temp, 4);
 } // setValue
 
-void BLECharacteristic::setValue(int& data32) {
+void BLECharacteristic::setValue(int data32) {
 	uint8_t temp[4];
 	temp[0] = data32;
 	temp[1] = data32 >> 8;
@@ -686,13 +686,13 @@ void BLECharacteristic::setValue(int& data32) {
 	setValue(temp, 4);
 } // setValue
 
-void BLECharacteristic::setValue(float& data32) {
+void BLECharacteristic::setValue(float data32) {
 	uint8_t temp[4];
 	*((float*)temp) = data32;
 	setValue(temp, 4);
 } // setValue
 
-void BLECharacteristic::setValue(double& data64) {
+void BLECharacteristic::setValue(double data64) {
 	uint8_t temp[8];
 	*((double*)temp) = data64;
 	setValue(temp, 8);

--- a/cpp_utils/BLECharacteristic.cpp
+++ b/cpp_utils/BLECharacteristic.cpp
@@ -657,7 +657,7 @@ void BLECharacteristic::setValue(uint8_t* data, size_t length) {
  * @param [in] Set the value of the characteristic.
  * @return N/A.
  */
-void BLECharacteristic::setValue(std::string& value) {
+void BLECharacteristic::setValue(std::string value) {
 	setValue((uint8_t*)(value.data()), value.length());
 } // setValue
 

--- a/cpp_utils/BLECharacteristic.h
+++ b/cpp_utils/BLECharacteristic.h
@@ -71,12 +71,12 @@ public:
 	void setNotifyProperty(bool value);
 	void setReadProperty(bool value);
 	void setValue(uint8_t* data, size_t size);
-	void setValue(std::string value);
-	void setValue(uint16_t& data16);
-	void setValue(uint32_t& data32);
-	void setValue(int& data32);
-	void setValue(float& data32);
-	void setValue(double& data64); 
+	void setValue(std::string& value);
+	void setValue(uint16_t data16);
+	void setValue(uint32_t data32);
+	void setValue(int data32);
+	void setValue(float data32);
+	void setValue(double data64); 
 	void setWriteProperty(bool value);
 	void setWriteNoResponseProperty(bool value);
 	std::string toString();

--- a/cpp_utils/BLECharacteristic.h
+++ b/cpp_utils/BLECharacteristic.h
@@ -71,7 +71,7 @@ public:
 	void setNotifyProperty(bool value);
 	void setReadProperty(bool value);
 	void setValue(uint8_t* data, size_t size);
-	void setValue(std::string& value);
+	void setValue(std::string value);
 	void setValue(uint16_t data16);
 	void setValue(uint32_t data32);
 	void setValue(int data32);

--- a/cpp_utils/BLEDevice.cpp
+++ b/cpp_utils/BLEDevice.cpp
@@ -485,7 +485,7 @@ gatts_event_handler BLEDevice::m_customGattsHandler = nullptr;
  */
 void BLEDevice::whiteListAdd(BLEAddress address) {
 	ESP_LOGD(LOG_TAG, ">> whiteListAdd: %s", address.toString().c_str());
-	esp_err_t errRc = esp_ble_gap_update_whitelist(true, *address.getNative());  // True to add an entry.
+	esp_err_t errRc = esp_ble_gap_update_whitelist(true, *address.getNative(), BLE_WL_ADDR_TYPE_RANDOM);  // True to add an entry.
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_ble_gap_update_whitelist: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 	}
@@ -499,7 +499,7 @@ void BLEDevice::whiteListAdd(BLEAddress address) {
  */
 void BLEDevice::whiteListRemove(BLEAddress address) {
 	ESP_LOGD(LOG_TAG, ">> whiteListRemove: %s", address.toString().c_str());
-	esp_err_t errRc = esp_ble_gap_update_whitelist(false, *address.getNative());  // False to remove an entry.
+	esp_err_t errRc = esp_ble_gap_update_whitelist(false, *address.getNative(), BLE_WL_ADDR_TYPE_RANDOM);  // False to remove an entry.
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_ble_gap_update_whitelist: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 	}

--- a/cpp_utils/CMakeLists.txt
+++ b/cpp_utils/CMakeLists.txt
@@ -5,6 +5,7 @@ set(COMPONENT_REQUIRES
   "json"
   "mdns"
   "nvs_flash"
+  "bt"
 )
 set(COMPONENT_PRIV_REQUIRES )
 

--- a/cpp_utils/HttpRequest.cpp
+++ b/cpp_utils/HttpRequest.cpp
@@ -39,7 +39,7 @@
 #include "GeneralUtils.h"
 
 #include <esp_log.h>
-#include <hwcrypto/sha.h>
+#include <esp32/sha.h>
 
 #define STATE_NAME  0
 #define STATE_VALUE 1

--- a/cpp_utils/SockServ.cpp
+++ b/cpp_utils/SockServ.cpp
@@ -70,7 +70,7 @@ SockServ::~SockServ() {
 			pSockServ->m_clientSet.insert(tempSock);
 			xQueueSendToBack(pSockServ->m_acceptQueue, &tempSock, portMAX_DELAY);
 			pSockServ->m_clientSemaphore.give();
-		} catch (std::exception e) {
+		} catch (std::exception& e) {
 			ESP_LOGD(LOG_TAG, "acceptTask ending");
 			pSockServ->m_clientSemaphore.give();   // Wake up any waiting clients.
 			FreeRTOS::deleteTask();

--- a/cpp_utils/Socket.cpp
+++ b/cpp_utils/Socket.cpp
@@ -432,7 +432,7 @@ int Socket::send(const uint8_t* data, size_t length) const {
 				}
 			}
 		} else {
-			rc = ::lwip_sendto(m_sock, data, length, 0);
+			rc = ::lwip_send(m_sock, data, length, 0);
 			if ((rc < 0) && (errno != EAGAIN)) {
 				// no cure for errors other than EAGAIN - log and exit
 				ESP_LOGE(LOG_TAG, "send: socket=%d, %s", m_sock, strerror(errno));

--- a/cpp_utils/Socket.cpp
+++ b/cpp_utils/Socket.cpp
@@ -60,7 +60,7 @@ Socket Socket::accept() {
 	ESP_LOGD(LOG_TAG, ">> accept: Accepting on %s; sockFd: %d, using SSL: %d", addressToString(&addr).c_str(), m_sock, getSSL());
 	struct sockaddr_in client_addr;
 	socklen_t sin_size;
-	int clientSockFD = ::lwip_accept_r(m_sock,  (struct sockaddr*) &client_addr, &sin_size);
+	int clientSockFD = ::lwip_accept(m_sock,  (struct sockaddr*) &client_addr, &sin_size);
 	//printf("------> new connection client %s:%d\n", inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
 	if (clientSockFD == -1) {
 		SocketException se(errno);
@@ -117,7 +117,7 @@ int Socket::bind(uint16_t port, uint32_t address) {
 	serverAddress.sin_family      = AF_INET;
 	serverAddress.sin_addr.s_addr = htonl(address);
 	serverAddress.sin_port        = htons(port);
-	int rc = ::lwip_bind_r(m_sock, (struct sockaddr*) &serverAddress, sizeof(serverAddress));
+	int rc = ::lwip_bind(m_sock, (struct sockaddr*) &serverAddress, sizeof(serverAddress));
 	if (rc != 0) {
 		ESP_LOGE(LOG_TAG, "<< bind: bind[socket=%d]: %d: %s", m_sock, errno, strerror(errno));
 		return rc;
@@ -144,7 +144,7 @@ int Socket::close() {
 	rc = 0;
 	if (m_sock != -1) {
 		ESP_LOGD(LOG_TAG, "Calling lwip_close on %d", m_sock);
-		rc = ::lwip_close_r(m_sock);
+		rc = ::lwip_close(m_sock);
 		if (rc != 0) {
 			ESP_LOGE(LOG_TAG, "Error with lwip_close: %d", rc);
 		}
@@ -170,7 +170,7 @@ int Socket::connect(struct in_addr address, uint16_t port) {
 	inet_ntop(AF_INET, &address, msg, sizeof(msg));
 	ESP_LOGD(LOG_TAG, "Connecting to %s:[%d]", msg, port);
 	createSocket();
-	int rc = ::lwip_connect_r(m_sock, (struct sockaddr*) &serverAddress, sizeof(struct sockaddr_in));
+	int rc = ::lwip_connect(m_sock, (struct sockaddr*) &serverAddress, sizeof(struct sockaddr_in));
 	if (rc == -1) {
 		ESP_LOGE(LOG_TAG, "connect_cpp: Error: %s", strerror(errno));
 		close();
@@ -268,7 +268,7 @@ int Socket::listen(uint16_t port, bool isDatagram, bool reuseAddress) {
 	// For a datagram socket, we don't execute a listen call.  That is is only for connection oriented
 	// sockets.
 	if (!isDatagram) {
-		rc = ::lwip_listen_r(m_sock, 5);
+		rc = ::lwip_listen(m_sock, 5);
 		if (rc == -1) {
 			ESP_LOGE(LOG_TAG, "<< listen: %s", strerror(errno));
 			return rc;
@@ -356,7 +356,7 @@ size_t Socket::receive(uint8_t* data, size_t length, bool exact) {
 				ESP_LOGD(LOG_TAG, "rc=%d, MBEDTLS_ERR_SSL_WANT_READ=%d", rc, MBEDTLS_ERR_SSL_WANT_READ);
 			} while (rc == MBEDTLS_ERR_SSL_WANT_WRITE || rc == MBEDTLS_ERR_SSL_WANT_READ);
 		} else {
-			rc = ::lwip_recv_r(m_sock, data, length, 0);
+			rc = ::lwip_recv(m_sock, data, length, 0);
 			if (rc == -1) {
 				ESP_LOGE(LOG_TAG, "receive: %s", strerror(errno));
 			}
@@ -374,7 +374,7 @@ size_t Socket::receive(uint8_t* data, size_t length, bool exact) {
 				rc = mbedtls_ssl_read(&m_sslContext, data, amountToRead);
 			} while (rc == MBEDTLS_ERR_SSL_WANT_WRITE || rc == MBEDTLS_ERR_SSL_WANT_READ);
 		} else {
-			rc = ::lwip_recv_r(m_sock, data, amountToRead, 0);
+			rc = ::lwip_recv(m_sock, data, amountToRead, 0);
 		}
 		if (rc == -1) {
 			ESP_LOGE(LOG_TAG, "receive: %s", strerror(errno));
@@ -432,7 +432,7 @@ int Socket::send(const uint8_t* data, size_t length) const {
 				}
 			}
 		} else {
-			rc = ::lwip_send_r(m_sock, data, length, 0);
+			rc = ::lwip_sendto(m_sock, data, length, 0);
 			if ((rc < 0) && (errno != EAGAIN)) {
 				// no cure for errors other than EAGAIN - log and exit
 				ESP_LOGE(LOG_TAG, "send: socket=%d, %s", m_sock, strerror(errno));

--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -218,8 +218,8 @@ void WiFi::dump() {
 	ESP_LOGD(LOG_TAG, "WiFi Dump");
 	ESP_LOGD(LOG_TAG, "---------");
 	char ipAddrStr[30];
-	ip_addr_t ip = ::dns_getserver(0);
-	inet_ntop(AF_INET, &ip, ipAddrStr, sizeof(ipAddrStr));
+	const ip_addr_t* ip = ::dns_getserver(0);
+	inet_ntop(AF_INET, ip, ipAddrStr, sizeof(ipAddrStr));
 	ESP_LOGD(LOG_TAG, "DNS Server[0]: %s", ipAddrStr);
 } // dump
 


### PR DESCRIPTION
I fixed a bunch of compile time errors for ESP-IDF 4.0.
I also fixed some pass by reference bugs (It does not make sense to pass an int/uint8_t as a reference if you just copy the value).